### PR TITLE
docs: expand logger README with Python and TypeScript usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ const logger = LoggerFactory.createFromEnvironment();
 
 **Python**
 ```bash
-export MOSAIC_LOG_LEVEL=INFO
-export MOSAIC_LOG_EMOJIS=true
+export ARTISSIST_LOG_LEVEL=INFO
+export ARTISSIST_LOG_EMOJIS=true
 ```
 
 ### Programmatic Configuration

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,6 +1,6 @@
-# Mosaic Logger - Python Client
+# Artissist Logger - Python Client
 
-Platform-agnostic logging client for the Mosaic Artist Assistant platform.
+Platform-agnostic logging client for the Artissist platform.
 
 ## Features
 
@@ -16,7 +16,7 @@ Platform-agnostic logging client for the Mosaic Artist Assistant platform.
 ## Installation
 
 ```bash
-pip install mosaic-logger
+pip install artissist-logger
 ```
 
 ### Development Installation
@@ -28,7 +28,7 @@ pip install -e .[dev]
 ## Quick Start
 
 ```python
-from mosaic_logger import LoggerFactory, LogEvent
+from artissist_logger import LoggerFactory, LogEvent
 
 # Create a backend logger
 logger = LoggerFactory.create_backend_logger(
@@ -83,7 +83,7 @@ logger = LoggerFactory.create_infrastructure_logger(
 
 ### Global Context
 ```python
-from mosaic_logger import ContextManager
+from artissist_logger import ContextManager, LoggerContext
 
 # Set global context
 ContextManager.set_context(LoggerContext(
@@ -136,7 +136,7 @@ LogEvent.PERFORMANCE_METRIC # ⚡ Performance measurements
 
 ### Custom Events
 ```python
-from mosaic_logger import EmojiResolver, EmojiMapping
+from artissist_logger import EmojiResolver, EmojiMapping
 
 # Create custom emoji mappings
 resolver = EmojiResolver()
@@ -161,7 +161,7 @@ await logger.info("Payment completed", custom_event="payment_processed")
 ## Error Handling
 
 ```python
-from mosaic_logger import ErrorInfo
+from artissist_logger import ErrorInfo
 
 try:
     # Some operation that might fail
@@ -182,7 +182,7 @@ except Exception as e:
 ## Metrics
 
 ```python
-from mosaic_logger import LogMetrics
+from artissist_logger import LogMetrics
 
 # Performance metrics
 await logger.info(
@@ -265,9 +265,9 @@ logger.error_sync("Connection failed", event=LogEvent.ERROR_OCCURRED)
 
 ### Environment Variables
 ```bash
-export MOSAIC_LOG_LEVEL=INFO
-export MOSAIC_LOG_EMOJIS=true
-export MOSAIC_LOG_FORMAT=json
+export ARTISSIST_LOG_LEVEL=INFO
+export ARTISSIST_LOG_EMOJIS=true
+export ARTISSIST_LOG_FORMAT=json
 ```
 
 ### Programmatic Configuration
@@ -291,14 +291,14 @@ logger = LoggerFactory.create_logger(**config)
 ### Running Tests
 ```bash
 pytest
-pytest --cov=mosaic_logger  # With coverage
+pytest --cov=artissist_logger  # With coverage
 ```
 
 ### Code Formatting
 ```bash
-black mosaic_logger/
-mypy mosaic_logger/
-flake8 mosaic_logger/
+black artissist_logger/
+mypy artissist_logger/
+flake8 artissist_logger/
 ```
 
 ### Build Package

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,78 @@
+# Artissist Logger - TypeScript Client
+
+TypeScript implementation of the Artissist Logger for browser and Node.js
+applications.
+
+## Features
+
+- 🚀 **Factory helpers** for frontend, backend, and agent environments
+- 🔌 **Adapter pattern** with console and file adapters out of the box
+- 🐛 **Structured events** with emoji mapping for rapid scanning
+- 🧠 **Context propagation** with `child()` loggers
+
+## Installation
+
+```bash
+pnpm add @artissist/logger
+# or
+npm install @artissist/logger
+```
+
+## Quick Start
+
+```typescript
+import { LoggerFactory, LogEvent } from '@artissist/logger';
+
+const logger = LoggerFactory.createBackendLogger({
+  service: 'api-service',
+  environment: 'development',
+  emojis: true
+});
+
+logger.info('Service booting', { event: LogEvent.SYSTEM_START });
+logger.error('Database unavailable', {
+  event: LogEvent.ERROR_OCCURRED,
+  metadata: { retry: true }
+});
+```
+
+## Context Management
+
+```typescript
+const requestLogger = logger.child({ correlationId: 'req-123' });
+requestLogger.info('Handling request');
+```
+
+## Custom Events
+
+```typescript
+LoggerFactory.addCustomEvents({ DEPLOYMENT_SUCCESS: '🚢' });
+logger.info('Ship it', { event: LogEvent.DEPLOYMENT_SUCCESS });
+```
+
+## Adapters
+
+Console adapter is enabled by default. To log to a file:
+
+```typescript
+const fileLogger = LoggerFactory.createBackendLogger({
+  service: 'api',
+  environment: 'production',
+  adapters: ['file'],
+  logFile: './logs/app.log'
+});
+```
+
+## Development
+
+Run tests and linting from the package root:
+
+```bash
+pnpm test
+pnpm lint
+```
+
+## License
+
+MIT License - see LICENSE file for details.
+


### PR DESCRIPTION
## Summary
- expand README with installation, quick start, and configuration examples for Python and TypeScript
- document logger factory helpers, context management, events/emoji mapping, and adapter configuration

## Testing
- `pnpm test` *(fails: LoggerFactory › error handling › should handle adapter creation errors gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c46e4370832ead187f37a2adea6b