### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/artissist/logger/security/code-scanning/2](https://github.com/artissist/logger/security/code-scanning/2)

To fix the issue, we need to explicitly specify a `permissions` block at either the workflow root or for each job that sets minimal permissions for GITHUB_TOKEN—typically `contents: read` for CI workflows that only require read access to the repository. Since neither job writes to the repository or manipulates pull requests, `contents: read` is sufficient and least privileged. The recommended way is to add this block at the top level of the YAML (directly below the workflow name, before `on:`) so it applies to all jobs. No additional imports or method definitions are needed; just the YAML modification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
